### PR TITLE
Do day 3 with Text.Regex

### DIFF
--- a/app/day3.hs
+++ b/app/day3.hs
@@ -1,0 +1,24 @@
+module Main where
+import System.Environment
+import Data.String.Utils
+
+--import Text.Regex.Base.Context
+import Text.Regex.Posix
+
+
+--type MyMatchText source = Array Int (source, (MatchOffset, MatchLength))
+
+main :: IO ()
+main = do
+  args <- getArgs
+  basicData <- readFile (head args)
+  fullData <- readFile (args !! 1)
+  putStrLn ("basic: 161 ?= " ++ show (part1 basicData))
+  putStrLn ("full: 161 ?= " ++ show (part1 fullData))
+
+
+part1 :: String -> Int
+part1 dataStr = sum ((product <$> map readInt) . tail <$> (\str -> str =~ "mul\\(([0-9]+),([0-9]+)\\)" :: [[String]]) dataStr)
+
+readInt :: String -> Int
+readInt = read


### PR DESCRIPTION
The problem was to identify all instances of `mul(42, 6)` (or with other numbers), multiply each pair together, and then sum up the lot.  This solves only part 1 because I don't have time for part 2.